### PR TITLE
chore: update react-email from v5 to v6.1.4

### DIFF
--- a/apps/web/app/api/send/route.tsx
+++ b/apps/web/app/api/send/route.tsx
@@ -1,4 +1,4 @@
-import { render } from '@react-email/components';
+import { render } from 'react-email';
 import VercelInviteUserEmail from 'transactional/emails/vercel-invite-user';
 
 export async function GET() {

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -8,8 +8,8 @@
     "start": "next start"
   },
   "dependencies": {
-    "@react-email/components": "1.0.1",
     "next": "16.0.8",
+    "react-email": "6.1.4",
     "react": "19.2.1",
     "react-dom": "19.2.1"
   },

--- a/packages/transactional/emails/vercel-invite-user.tsx
+++ b/packages/transactional/emails/vercel-invite-user.tsx
@@ -13,7 +13,7 @@ import {
   Section,
   Tailwind,
   Text,
-} from '@react-email/components';
+} from 'react-email';
 
 interface VercelInviteUserEmailProps {
   username?: string;

--- a/packages/transactional/package.json
+++ b/packages/transactional/package.json
@@ -9,13 +9,13 @@
     "start": "email start -p 3001"
   },
   "dependencies": {
-    "@react-email/ui": "6.1.4",
     "react": "19.2.1",
     "react-dom": "19.2.1",
     "react-email": "6.1.4"
   },
   "devDependencies": {
     "@react-email/preview-server": "5.2.10",
+    "@react-email/ui": "6.1.4",
     "@types/react": "19.2.7",
     "@types/react-dom": "19.2.3"
   }

--- a/packages/transactional/package.json
+++ b/packages/transactional/package.json
@@ -15,6 +15,7 @@
     "react-email": "6.1.4"
   },
   "devDependencies": {
+    "@react-email/preview-server": "5.2.10",
     "@types/react": "19.2.7",
     "@types/react-dom": "19.2.3"
   }

--- a/packages/transactional/package.json
+++ b/packages/transactional/package.json
@@ -14,7 +14,6 @@
     "react-email": "6.1.4"
   },
   "devDependencies": {
-    "@react-email/preview-server": "5.2.10",
     "@react-email/ui": "6.1.4",
     "@types/react": "19.2.7",
     "@types/react-dom": "19.2.3"

--- a/packages/transactional/package.json
+++ b/packages/transactional/package.json
@@ -9,14 +9,12 @@
     "start": "email start -p 3001"
   },
   "dependencies": {
-    "@react-email/components": "1.0.1",
     "react": "19.2.1",
     "react-dom": "19.2.1"
   },
   "devDependencies": {
-    "@react-email/preview-server": "5.0.7",
     "@types/react": "19.2.7",
     "@types/react-dom": "19.2.3",
-    "react-email": "5.0.7"
+    "react-email": "6.1.4"
   }
 }

--- a/packages/transactional/package.json
+++ b/packages/transactional/package.json
@@ -9,12 +9,13 @@
     "start": "email start -p 3001"
   },
   "dependencies": {
+    "@react-email/ui": "6.1.4",
     "react": "19.2.1",
-    "react-dom": "19.2.1"
+    "react-dom": "19.2.1",
+    "react-email": "6.1.4"
   },
   "devDependencies": {
     "@types/react": "19.2.7",
-    "@types/react-dom": "19.2.3",
-    "react-email": "6.1.4"
+    "@types/react-dom": "19.2.3"
   }
 }


### PR DESCRIPTION
## Summary

- Replace `@react-email/components` and `@react-email/preview-server` with `react-email` v6.1.4
- Update all imports from `@react-email/components` → `react-email`

Closes DEV-483